### PR TITLE
Fix unweighted calculation for Metric::MemoryLoad force_down_at

### DIFF
--- a/lib/litmus_paper/metric/memory_load.rb
+++ b/lib/litmus_paper/metric/memory_load.rb
@@ -12,12 +12,12 @@ module LitmusPaper
       end
 
       def current_health
-        health = mem_capacity
-        weighted_health = (@weight * health).floor
+        unweighted_health = (100 * (mem_available.to_f / mem_total)).floor
+        weighted_health = (@weight * mem_capacity).floor
 
         if weighted_health > @weight
           @weight
-        elsif force_down_at && health <= force_down_at
+        elsif force_down_at && unweighted_health <= force_down_at
           throw(:force_state, :down)
         elsif weighted_health < 1
           0

--- a/spec/litmus_paper/metric/memory_load_spec.rb
+++ b/spec/litmus_paper/metric/memory_load_spec.rb
@@ -54,6 +54,22 @@ describe LitmusPaper::Metric::MemoryLoad do
         mem_load = LitmusPaper::Metric::MemoryLoad.new(50, nil, 2)
         expect { mem_load.current_health }.to throw_symbol(:force_state, :down)
       end
+
+      it 'throws :force_state with :down when below force_down_at and not weighted according to baseline' do
+        LitmusPaper::Metric::MemoryLoad.any_instance.stub(
+          mem_total: 4000000,
+          mem_available: 80000,
+        )
+        mem_load = LitmusPaper::Metric::MemoryLoad.new(50, 85, 2)
+        expect { mem_load.current_health }.to throw_symbol(:force_state, :down)
+
+        LitmusPaper::Metric::MemoryLoad.any_instance.stub(
+          mem_total: 4000000,
+          mem_available: 120000,
+        )
+        mem_load = LitmusPaper::Metric::MemoryLoad.new(50, 85, 2)
+        expect { mem_load.current_health }.not_to throw_symbol(:force_state, :down)
+      end
     end
   end
 


### PR DESCRIPTION
The calculation was (1) comparing against a fraction, rather than a full
percent value, and (2) comparing against a value based on baseline memory
rather than total.

🤦 